### PR TITLE
[Fix]タグ検索大文字小文字区別なし

### DIFF
--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,0 +1,1 @@
+ActsAsTaggableOn.strict_case_match = true


### PR DESCRIPTION
タグ検索時、本番環境のみ大文字と小文字を区別されてしまうため、
その設定を変更（テスト）